### PR TITLE
fixed falsy payload case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ export function createDuck(name, app) {
         type,
       };
 
-      if (payload) action.payload = payload;
+      if (payload !== undefined) action.payload = payload;
 
       return action;
     };


### PR DESCRIPTION
there could be some simple payloads like `0`, `''` or `false`, that will be skipped in current implementation. for that reason need to check against `undefined`.